### PR TITLE
Allow property -Dwebapp.app-server-metrics.source...

### DIFF
--- a/src/main/java/nz/org/geonet/metrics/sender/Util.java
+++ b/src/main/java/nz/org/geonet/metrics/sender/Util.java
@@ -25,6 +25,11 @@ public class Util {
     public static String source() {
         String source = null;
 
+        final String property = System.getProperty("webapp.app-server-metrics.source");
+        if(property != null && property.length() > 0) {
+            return property;
+        }
+
         try {
             source = InetAddress.getLocalHost().getHostName();
         } catch (Exception e) {


### PR DESCRIPTION
...to specify the source string, if running several containers on one system.
